### PR TITLE
Improve robustness of instrument polling against invalid data

### DIFF
--- a/init_connection.py
+++ b/init_connection.py
@@ -1,6 +1,33 @@
 import pyvisa
 
 class logger:
+    @staticmethod
+    def _safe_float(raw_value, source: str, measurement: str):
+        """Best-effort conversion of VISA query responses to float.
+
+        The Lake Shore instruments occasionally return non-numeric strings (e.g.
+        "OL" for open loop).  Instead of letting ``float`` raise and breaking the
+        rest of the polling cycle, coerce those responses to ``None`` and emit a
+        warning so downstream logging can continue for other channels.
+        """
+
+        if raw_value is None:
+            return None
+
+        try:
+            return float(raw_value)
+        except (TypeError, ValueError):
+            text = str(raw_value).strip()
+            if text:
+                print(
+                    f"Warning: {source} returned non-numeric value for {measurement}: {text!r}"
+                )
+            else:
+                print(
+                    f"Warning: {source} returned empty value for {measurement}; treating as None"
+                )
+            return None
+
     def __init__(self, open_330bb: bool = True, open_330sp: bool = True, open_336: bool = True):
         self.rm = pyvisa.ResourceManager()
         if open_330bb:
@@ -68,39 +95,91 @@ class logger:
     # For the 330s, we will poll setpoint and TC temperature
 
     def poll_330BB(self):
+        setpoint = temperature = heater = None
         try:
-            setpoint = self.LS330BB.query("SETP?")
-            temperature = self.LS330BB.query("TEMP?")
-            heater = self.LS330BB.query("HEAT?")
-            return float(setpoint), float(temperature), float(heater)
+            setpoint = self._safe_float(
+                self.LS330BB.query("SETP?"), "LS330BB", "setpoint"
+            )
         except Exception as e:
-            print(f"Error polling LS330BB: {e}")
-            return None, None, None
+            print(f"Error polling LS330BB setpoint: {e}")
+
+        try:
+            temperature = self._safe_float(
+                self.LS330BB.query("TEMP?"), "LS330BB", "temperature"
+            )
+        except Exception as e:
+            print(f"Error polling LS330BB temperature: {e}")
+
+        try:
+            heater = self._safe_float(
+                self.LS330BB.query("HEAT?"), "LS330BB", "heater"
+            )
+        except Exception as e:
+            print(f"Error polling LS330BB heater: {e}")
+
+        return setpoint, temperature, heater
 
     def poll_330SP(self):
+        setpoint = temperature = heater = None
         try:
-            setpoint = self.LS330SP.query("SETP?")
-            temperature = self.LS330SP.query("TEMP?")
-            heater = self.LS330SP.query("HEAT?")
-            return float(setpoint), float(temperature), float(heater)
+            setpoint = self._safe_float(
+                self.LS330SP.query("SETP?"), "LS330SP", "setpoint"
+            )
         except Exception as e:
-            print(f"Error polling LS330SP: {e}")
-            return None, None, None
+            print(f"Error polling LS330SP setpoint: {e}")
+
+        try:
+            temperature = self._safe_float(
+                self.LS330SP.query("TEMP?"), "LS330SP", "temperature"
+            )
+        except Exception as e:
+            print(f"Error polling LS330SP temperature: {e}")
+
+        try:
+            heater = self._safe_float(
+                self.LS330SP.query("HEAT?"), "LS330SP", "heater"
+            )
+        except Exception as e:
+            print(f"Error polling LS330SP heater: {e}")
+
+        return setpoint, temperature, heater
 
     # For the 336, we will poll setpoints and temperatures for
     # channels 1 and 2 (corresponding to A and B on the physical
     # instrument)
 
     def poll_336(self):
+        a_setpoint = a_temp = b_setpoint = b_temp = None
+
         try:
-            setpoint_A = self.LS336.query("SETP? 1")
-            temperature_A = self.LS336.query("TEMP? 1")
-            setpoint_B = self.LS336.query("SETP? 2")
-            temperature_B = self.LS336.query("TEMP? 2")
-            return (float(setpoint_A), float(temperature_A)), (float(setpoint_B), float(temperature_B))
+            a_setpoint = self._safe_float(
+                self.LS336.query("SETP? 1"), "LS336", "A.setpoint"
+            )
         except Exception as e:
-            print(f"Error polling LS336: {e}")
-            return None, None
+            print(f"Error polling LS336 channel A setpoint: {e}")
+
+        try:
+            a_temp = self._safe_float(
+                self.LS336.query("TEMP? 1"), "LS336", "A.temperature"
+            )
+        except Exception as e:
+            print(f"Error polling LS336 channel A temperature: {e}")
+
+        try:
+            b_setpoint = self._safe_float(
+                self.LS336.query("SETP? 2"), "LS336", "B.setpoint"
+            )
+        except Exception as e:
+            print(f"Error polling LS336 channel B setpoint: {e}")
+
+        try:
+            b_temp = self._safe_float(
+                self.LS336.query("TEMP? 2"), "LS336", "B.temperature"
+            )
+        except Exception as e:
+            print(f"Error polling LS336 channel B temperature: {e}")
+
+        return (a_setpoint, a_temp), (b_setpoint, b_temp)
 
     # Confirm connection to instruments:
     def test_instruments(self):


### PR DESCRIPTION
## Summary
- add a helper to safely coerce instrument responses to floats and warn on non-numeric values
- isolate each Lake Shore query so one bad response does not block other channel readings

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e433d55d38832988d2a18280b8150a