### PR TITLE
Improve console polling presentation

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -27,6 +27,9 @@ DEFAULT_DB_PATH = os.environ.get(
 
 
 STOP = False
+BOLD = "\033[1m"
+RESET = "\033[0m"
+SPINNER_FRAMES = "|/-\\"
 
 
 def _handle_sigint(signum, frame):
@@ -122,6 +125,73 @@ def _poll_once(inst: init_connection.logger, sources: set[str] | None = None):
         yield (ts, "LS336", "B.temperature[K]", b_temp, None)
 
 
+def _format_value(channel: str, value) -> str:
+    if isinstance(value, (int, float)):
+        try:
+            v_str = f"{value:.6g}"
+        except Exception:
+            v_str = str(value)
+    else:
+        v_str = "NA"
+
+    if "temperature" in channel.lower() and v_str != "NA":
+        return f"{BOLD}{v_str}{RESET}"
+    return v_str
+
+
+def _print_poll_block(poll_index: int, rows: list[tuple[str, str, str, object, str | None]]):
+    header_line = "=" * 60
+    print("\n" + header_line)
+
+    poll_ts = rows[0][0] if rows else datetime.now().astimezone().isoformat()
+    try:
+        dt = datetime.fromisoformat(poll_ts)
+        poll_label = dt.strftime("%Y-%m-%d %H:%M:%S %Z")
+    except Exception:
+        poll_label = poll_ts
+
+    title = f" Poll #{poll_index} — {poll_label} "
+    print(title.center(len(header_line), "="))
+    print(header_line)
+
+    if not rows:
+        print("(No readings returned this cycle)")
+        return
+
+    for ts, source, channel, value, _extra in rows:
+        try:
+            dt = datetime.fromisoformat(ts)
+            human_ts = dt.strftime("%Y-%m-%d %H:%M:%S")
+        except Exception:
+            human_ts = ts
+        value_str = _format_value(channel, value)
+        line = f"{human_ts}  {source:<7}  {channel:<18} = {value_str}"
+        print(line)
+
+
+def _countdown(seconds: float):
+    if seconds <= 0:
+        return
+
+    end_time = time.monotonic() + seconds
+    frame_index = 0
+    max_width = 0
+
+    while not STOP:
+        remaining = end_time - time.monotonic()
+        if remaining <= 0:
+            break
+        spinner = SPINNER_FRAMES[frame_index % len(SPINNER_FRAMES)]
+        frame_index += 1
+        msg = f"Next poll in {remaining:4.1f}s {spinner}"
+        max_width = max(max_width, len(msg))
+        print("\r" + msg.ljust(max_width), end="", flush=True)
+        time.sleep(0.2)
+
+    print("\r" + " " * max_width + "\r", end="", flush=True)
+    print(flush=True)
+
+
 def poll_and_log_sqlite(
     interval_sec: int = 10,
     db_path: str = DEFAULT_DB_PATH,
@@ -149,8 +219,12 @@ def poll_and_log_sqlite(
     inst = init_connection.logger(open_330bb=open_330bb, open_330sp=open_330sp, open_336=open_336)
     db = _connect_db(db_path)
 
+    poll_index = 0
+
     try:
         while not STOP:
+            cycle_start = time.monotonic()
+            poll_index += 1
             rows = list(_poll_once(inst, sources=sources))
             # Write to DB with retry to handle concurrent writer
             max_retries = 5
@@ -174,23 +248,12 @@ def poll_and_log_sqlite(
                         continue
                     else:
                         raise
-            # Print to console (human-readable local time)
-            for ts, source, channel, value, _extra in rows:
-                v = value
-                if isinstance(v, (int, float)):
-                    try:
-                        v_str = f"{v:.6g}"
-                    except Exception:
-                        v_str = str(v)
-                else:
-                    v_str = "NA"
-                try:
-                    dt = datetime.fromisoformat(ts)
-                    human_ts = dt.strftime("%Y-%m-%d %H:%M:%S")
-                except Exception:
-                    human_ts = ts
-                print(f"{human_ts}  {source}  {channel} = {v_str}")
-            time.sleep(interval_sec)
+            _print_poll_block(poll_index, rows)
+
+            elapsed = time.monotonic() - cycle_start
+            remaining = max(0.0, float(interval_sec) - elapsed)
+            if not STOP:
+                _countdown(remaining)
     finally:
         try:
             db.close()


### PR DESCRIPTION
## Summary
- prettify the polling console output with cycle headers and formatted readings
- emphasize temperature values and show an animated countdown until the next poll

## Testing
- python -m py_compile logger.py

------
https://chatgpt.com/codex/tasks/task_e_68e437bb93308329acf637baa218ec18